### PR TITLE
Powermeter py3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,24 @@ This is a Python module for the HIOKI 3334 power meter in SEELab.
 
 ## Installation
 
-Clone the latest release of this repository (or download its archive), `cd` into it, then:
+Download the desired version from the release page and decompress it. `cd` into it, then:
 
 ```shell
+# for v1.0 and Python 2.7
 pip2 install .
+# or for v2.0 and Python 3.5
+pip3 install .
 ```
 
-The current version (v1.0) works for Python 2.7.
+Note that v1.0 works for Python 2.7, while the current version in this repo (v2.0) supports Python 3.5.
 
-By default, the module will be installed to your packages library for Python 2.7. However, if you do want to install the module in "editable" mode, which will be based on the code in the current directory:
+By default, the module will be installed to your packages library for Python. However, if you do want to install the module in "editable" mode, which will be based on the code in the current directory:
 
 ```shell
+# for v1.0 and Python 2.7
 pip2 install -e .
+# or for v2.0 and Python 3.5
+pip3 install -e .
 ```
 
 ## Demo

--- a/demo/demo_simple.py
+++ b/demo/demo_simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 '''
 A simple power reading demo for powermeter
@@ -12,7 +12,7 @@ PWR_FILE = "./power.txt"
 MEASURE_TIME = 10
 MSG = "Collecting power measurements for {} seconds...\r\n".format(
         MEASURE_TIME)
-MSG += "Check {} for detailed traces afterwards.".format(PWR_FILE) 
+MSG += "Check {} for detailed traces afterwards.".format(PWR_FILE)
 
 def pwr_callback(pwr):
     '''
@@ -22,7 +22,7 @@ def pwr_callback(pwr):
 
     Args:
         pwr (float): the power measurement in W.
-    
+
     Attributes:
         pwr_callback.start_time (float): the time that first data comes in, seconds
         pwr_callback.pwr_data: [time stamp (s), power (W)]
@@ -37,7 +37,7 @@ def pwr_callback(pwr):
 pwr_callback.pwr_data = []
 pwr_callback.start_time = None
 
-def main():    
+def main():
     '''
     main function
     Start measurement for 10s, save traces to PWR_FILE,

--- a/powermeter/powermeter.py
+++ b/powermeter/powermeter.py
@@ -9,6 +9,7 @@ import threading
 import serial, select
 import time
 import signal
+from functools import reduce
 
 PORT = "/dev/ttyUSB0"
 
@@ -35,22 +36,22 @@ class PowerMeter(object):
         psu.flushInput()
         psu.flushOutput()
 
-        psu.write("\r\n")
+        psu.write(b"\r\n")
         #time.sleep(1)
-        #psu.write("*IDN?\r\n")
-        #psu.write(":MEASure?\r\n")
+        #psu.write(b"*IDN?\r\n")
+        #psu.write(b":MEASure?\r\n")
 
-        psu.write(":HEAD OFF\r\n") # no header
+        psu.write(bytes(":HEAD OFF\r\n", 'UTF-8')) # no header
 
-        #psu.write(":DATAout:ITEM 2,0\r\n"); item = "current" # for current
-        #psu.write(":DATAout:ITEM 4,0\r\n"); item = "power" # for power
-        #psu.write(":DATAout:ITEM 1,0\r\n"); item = "volt" # for voltage
-        psu.write(":DATAout:ITEM 35,0\r\n"); item = "volt,curr,pf" # for more details
-        #psu.write(":DATAout:ITEM?\r\n")
+        #psu.write(b":DATAout:ITEM 2,0\r\n"); item = "current" # for current
+        #psu.write(b":DATAout:ITEM 4,0\r\n"); item = "power" # for power
+        #psu.write(b":DATAout:ITEM 1,0\r\n"); item = "volt" # for voltage
+        psu.write(b":DATAout:ITEM 35,0\r\n"); item = "volt,curr,pf" # for more details
+        #psu.write(b":DATAout:ITEM?\r\n")
         #time.sleep(1)
 
-        #psu.write(":CURR:RANG 0.1\r\n") # Current range to minimum
-        #psu.write(":CURR:RANG 1.0\r\n") # Current range to minimum
+        #psu.write(b":CURR:RANG 0.1\r\n") # Current range to minimum
+        #psu.write(b":CURR:RANG 1.0\r\n") # Current range to minimum
 
         return psu, item
 
@@ -72,14 +73,15 @@ class PowerMeter(object):
         bTypeError = False
         while self.is_loop_running:
             if bNeedtoMeasure == True:
-                psu.write(":MEAS?\r\n")
+                psu.write(b":MEAS?\r\n")
                 bNeedtoMeasure = False
 
             try:
                 read_char = psu.read()
+                read_char = read_char.decode('UTF-8')
             except serial.serialutil.SerialException:
                 break
-            except select.error, v:
+            except (select.error, v):
                 break
 
             try:

--- a/powermeter/powermeter.py
+++ b/powermeter/powermeter.py
@@ -41,7 +41,7 @@ class PowerMeter(object):
         #psu.write(b"*IDN?\r\n")
         #psu.write(b":MEASure?\r\n")
 
-        psu.write(bytes(":HEAD OFF\r\n", 'UTF-8')) # no header
+        psu.write(b":HEAD OFF\r\n") # no header
 
         #psu.write(b":DATAout:ITEM 2,0\r\n"); item = "current" # for current
         #psu.write(b":DATAout:ITEM 4,0\r\n"); item = "power" # for power

--- a/powermeter/powermeter.py
+++ b/powermeter/powermeter.py
@@ -1,7 +1,7 @@
-#!/usr/bin/python 
+#!/usr/bin/python3
 
 # Yeseong Kim, UCSD 2017-2018,
-# Reading total power consumption from HIOKI 3334 multimeter 
+# Reading total power consumption from HIOKI 3334 multimeter
 # This is forked from the old serial_measurement script.
 import sys
 import os
@@ -40,7 +40,7 @@ class PowerMeter(object):
         #psu.write("*IDN?\r\n")
         #psu.write(":MEASure?\r\n")
 
-        psu.write(":HEAD OFF\r\n") # no header 
+        psu.write(":HEAD OFF\r\n") # no header
 
         #psu.write(":DATAout:ITEM 2,0\r\n"); item = "current" # for current
         #psu.write(":DATAout:ITEM 4,0\r\n"); item = "power" # for power
@@ -57,14 +57,14 @@ class PowerMeter(object):
     # ** Recommend not to use this function as an external function **
     # ** Instead, use run(self) for async running
     def run_in_loop(self):
-        # Initialize PSU and header 
+        # Initialize PSU and header
         psu, item = self.init_psu()
         extra_item_size = item.count(',')
         if extra_item_size > 0:
             item += ",mul"
         self.log("time_stamp," + item)
 
-        # Start of the loop 
+        # Start of the loop
         self.is_loop_running = True
         bNeedtoMeasure = True
         read_idx = 0
@@ -107,7 +107,7 @@ class PowerMeter(object):
                     if extra_item_size > 0:
                         # multiply everything: power
                         mul = reduce(lambda x, y: x*y, vallist)
-                        output_str += "," + str(mul) 
+                        output_str += "," + str(mul)
                         if self.callback is not None:
                             self.callback(mul)
 
@@ -121,7 +121,7 @@ class PowerMeter(object):
 
         psu.close()
 
-    # Start asynchronous measurement 
+    # Start asynchronous measurement
     # The created loop can be terminated using stop()
     def run(self, callback=None):
         # check whether the port exists
@@ -139,7 +139,7 @@ class PowerMeter(object):
         self.loop_thread = threading.Thread(target=self.run_in_loop)
         self.loop_thread.start()
 
-    # Finish the created asynchronous measurement 
+    # Finish the created asynchronous measurement
     def stop(self):
         # Stop running thread
         assert(self.loop_thread is not None)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ SHORT_DESCRIPTION = (
     'Python module for HIOKI 3334 power meter in SEELab.'
 )
 
-VERSION = '1.0'
+VERSION = '2.0'
 
 DEPENDENCIES = [
     'pyserial'
@@ -20,6 +20,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=['powermeter'],
-    python_requires='>=2.7.13',
+    python_requires='>=3.5.3',
     install_requires=DEPENDENCIES
 )


### PR DESCRIPTION
- Fix the bytes-to-string conversion from py2.7 to py3.5
- Modify the `setup.py` for version 2.0.